### PR TITLE
Fix/external pickups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- External pickup points endpoint.
+
+## Added
+
+- Fallback if external pickup points promise failed.
+
 ## [3.0.1] - 2019-09-05
 
 ### Changed

--- a/react/ModalState.js
+++ b/react/ModalState.js
@@ -13,7 +13,7 @@ import {
   GEOLOCATION_SEARCHING,
   BEST_PICKUPS_AMOUNT,
 } from './constants'
-import { getExternalPickupPoints, getAvailablePickups } from './fetchers'
+import { fetchExternalPickupPoints, getAvailablePickups } from './fetchers'
 import { getPickupOptions, getUniquePickupPoints } from './utils/pickupUtils'
 import { getPickupSlaString } from './utils/GetString'
 import { getBestPickupPoints } from './utils/bestPickups'
@@ -63,23 +63,13 @@ class ModalState extends Component {
   }
 
   componentDidMount() {
-    const { externalPickupPoints } = this.state
     const thisAddressCoords =
       this.props.address &&
       this.props.address.geoCoordinates &&
       this.props.address.geoCoordinates.value
 
     if (thisAddressCoords.length > 0) {
-      getExternalPickupPoints(thisAddressCoords)
-        .then(data =>
-          this.setState({
-            externalPickupPoints: data.items.map(item => ({
-              ...item.pickupPoint,
-              distance: null,
-            })),
-          })
-        )
-        .catch(() => this.setState({ externalPickupPoints }))
+      this.getExternalPickupOptions(thisAddressCoords)
     }
   }
 
@@ -150,16 +140,7 @@ class ModalState extends Component {
     }
 
     if (isDifferentGeoCoords(thisAddressCoords, prevAddressCoords)) {
-      getExternalPickupPoints(thisAddressCoords)
-        .then(data =>
-          this.setState({
-            externalPickupPoints: data.items.map(item => ({
-              ...item.pickupPoint,
-              distance: null,
-            })),
-          })
-        )
-        .catch(() => this.setState({ externalPickupPoints }))
+      this.getExternalPickupOptions(thisAddressCoords)
     }
 
     if (thisPickupOptions !== prevPickupOptions) {
@@ -443,6 +424,21 @@ class ModalState extends Component {
       distance: null,
       pickupDistance: null,
     }))
+  }
+
+  getExternalPickupOptions = geoCoordinates => {
+    const { externalPickupPoints } = this.state
+
+    fetchExternalPickupPoints(geoCoordinates)
+      .then(data =>
+        this.setState({
+          externalPickupPoints: data.items.map(item => ({
+            ...item.pickupPoint,
+            distance: null,
+          })),
+        })
+      )
+      .catch(() => this.setState({ externalPickupPoints }))
   }
 
   render() {

--- a/react/ModalState.js
+++ b/react/ModalState.js
@@ -63,20 +63,23 @@ class ModalState extends Component {
   }
 
   componentDidMount() {
+    const { externalPickupPoints } = this.state
     const thisAddressCoords =
       this.props.address &&
       this.props.address.geoCoordinates &&
       this.props.address.geoCoordinates.value
 
     if (thisAddressCoords.length > 0) {
-      getExternalPickupPoints(thisAddressCoords).then(data =>
-        this.setState({
-          externalPickupPoints: data.items.map(item => ({
-            ...item,
-            distance: null,
-          })),
-        })
-      )
+      getExternalPickupPoints(thisAddressCoords)
+        .then(data =>
+          this.setState({
+            externalPickupPoints: data.items.map(item => ({
+              ...item.pickupPoint,
+              distance: null,
+            })),
+          })
+        )
+        .catch(() => this.setState({ externalPickupPoints }))
     }
   }
 
@@ -96,6 +99,7 @@ class ModalState extends Component {
       activeState,
       askForGeolocation,
       selectedPickupPoint,
+      externalPickupPoints,
     } = this.state
 
     const thisAddressCoords =
@@ -146,9 +150,16 @@ class ModalState extends Component {
     }
 
     if (isDifferentGeoCoords(thisAddressCoords, prevAddressCoords)) {
-      getExternalPickupPoints(thisAddressCoords).then(data =>
-        this.setState({ externalPickupPoints: data.items })
-      )
+      getExternalPickupPoints(thisAddressCoords)
+        .then(data =>
+          this.setState({
+            externalPickupPoints: data.items.map(item => ({
+              ...item.pickupPoint,
+              distance: null,
+            })),
+          })
+        )
+        .catch(() => this.setState({ externalPickupPoints }))
     }
 
     if (thisPickupOptions !== prevPickupOptions) {

--- a/react/ModalState.js
+++ b/react/ModalState.js
@@ -274,7 +274,7 @@ class ModalState extends Component {
 
     this.setSelectedPickupPoint({
       pickupPoint: bestPickupOptions[previousIndex],
-      isBestPickupPoint: previousIndex < BEST_PICKUPS_AMOUNT,
+      isSelectedBestPickupPoint: previousIndex < BEST_PICKUPS_AMOUNT,
     })
   }
 
@@ -289,7 +289,7 @@ class ModalState extends Component {
 
     this.setSelectedPickupPoint({
       pickupPoint: bestPickupOptions[nextIndex],
-      isBestPickupPoint: nextIndex < BEST_PICKUPS_AMOUNT,
+      isSelectedBestPickupPoint: nextIndex < BEST_PICKUPS_AMOUNT,
     })
   }
 

--- a/react/components/Map.js
+++ b/react/components/Map.js
@@ -467,7 +467,8 @@ class Map extends Component {
           )
           const markerIconImage =
             index < BEST_PICKUPS_AMOUNT &&
-            bestPickupOptions.length > BEST_PICKUPS_AMOUNT
+            bestPickupOptions.length > BEST_PICKUPS_AMOUNT &&
+            this.markers.length === 0
               ? bestMarkerIcon
               : markerIcon
           const isScaledMarker =

--- a/react/components/PickupPointInfo.js
+++ b/react/components/PickupPointInfo.js
@@ -98,7 +98,7 @@ class PickupPointInfo extends Component {
     const shouldShowEstimate = pickupPoint && pickupPoint.shippingEstimate
     const isBestPickupPointAndAvailable =
       pickupPoint.pickupStoreInfo &&
-      (isBestPickupPoint || isSelectedBestPickupPoint)
+      (isBestPickupPoint || (isSelectedBestPickupPoint && !isList))
 
     return (
       <div

--- a/react/components/PickupPointsList.js
+++ b/react/components/PickupPointsList.js
@@ -87,7 +87,9 @@ class PickupPointsList extends PureComponent {
               .filter((_, index) => index < BEST_PICKUPS_AMOUNT)
               .map(pickupPoint => (
                 <div
-                  className={`${styles.pointsItem} pkpmodal-points-item`}
+                  className={`${
+                    styles.pointsItem
+                  } pkpmodal-points-item best-pickupPoint-${pickupPoint.id}`}
                   key={`best-pickupPoint-${pickupPoint.id}`}>
                   <PickupPointInfo
                     isList
@@ -136,10 +138,13 @@ class PickupPointsList extends PureComponent {
               threshold={1}>
               {currentPickupPoints.map(pickupPoint => (
                 <div
-                  className={`${styles.pointsItem} pkpmodal-points-item`}
+                  className={`${
+                    styles.pointsItem
+                  } pkpmodal-points-item pickupPoint-${pickupPoint.id}`}
                   key={`pickupPoint-${pickupPoint.id}`}>
                   <PickupPointInfo
                     isList
+                    isBestPickupPoint={false}
                     items={items}
                     logisticsInfo={logisticsInfo}
                     pickupPoint={pickupPoint}

--- a/react/fetchers/index.js
+++ b/react/fetchers/index.js
@@ -3,8 +3,8 @@ import { PICKUP_IN_STORE, SEARCH } from '../constants'
 
 export function getExternalPickupPoints(geoCoordinates) {
   return fetch(
-    `/api/checkout/pub/pickup-points?lat=${geoCoordinates[1]}&lon=${
-      geoCoordinates[0]
+    `/api/checkout/pub/pickup-points?geoCoordinates=${geoCoordinates[0]};${
+      geoCoordinates[1]
     }&page=1&pageSize=100`
   ).then(response => response.json())
 }

--- a/react/fetchers/index.js
+++ b/react/fetchers/index.js
@@ -1,7 +1,7 @@
 import { newAddress } from '../utils/newAddress'
 import { PICKUP_IN_STORE, SEARCH } from '../constants'
 
-export function getExternalPickupPoints(geoCoordinates) {
+export function fetchExternalPickupPoints(geoCoordinates) {
   return fetch(
     `/api/checkout/pub/pickup-points?geoCoordinates=${geoCoordinates[0]};${
       geoCoordinates[1]


### PR DESCRIPTION
#### What is the purpose of this pull request?

### Changed

- External pickup points endpoint

## Added

- Fallback if external pickup points promise failed

#### What problem is this solving?
External Pickup points would not load with previous endpoint.

#### How should this be manually tested?
1. Add [items to cart](https://beta--vtexgame1.myvtex.com/checkout/cart/add?&workspace=beta&sku=298&qty=1&seller=1&sc=1)
2. Go to Shipping
3. Select Pickup tab
4. Search for `Praia de botafogo 300`
5. Pickup points should show normally.

#### Screenshots or example usage
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
