### PR TITLE
Fix pickup points list to only show more pickup points button if has more than minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pickups list to only show button if has more than three pickup points
+
 ## [3.0.2] - 2019-09-09
 
 ### Changed

--- a/react/components/PickupPointsList.js
+++ b/react/components/PickupPointsList.js
@@ -76,6 +76,13 @@ class PickupPointsList extends PureComponent {
 
     const hasMorePickupPoints = currentAmount <= pickupPoints.length
 
+    const hasMinimumPickupPoints =
+      bestPickupOptions.length > BEST_PICKUPS_AMOUNT
+
+    const showOtherList = hasMinimumPickupPoints && showOtherPickupPoints
+
+    const showOtherButton = hasMinimumPickupPoints && !showOtherPickupPoints
+
     return (
       <div className={`${styles.pointsList} pkpmodal-points-list`}>
         {bestPickupOptions.length > 0 && (
@@ -107,7 +114,7 @@ class PickupPointsList extends PureComponent {
                   />
                 </div>
               ))}
-            {!showOtherPickupPoints && (
+            {showOtherButton && (
               <Button
                 id="pkpmodal-show-list-btn"
                 kind="secondary"
@@ -121,7 +128,7 @@ class PickupPointsList extends PureComponent {
             )}
           </Fragment>
         )}
-        {showOtherPickupPoints && (
+        {showOtherList && (
           <Fragment>
             <p className={styles.pickupListTitle}>
               {translate(intl, 'resultsOrderedByDistance')}


### PR DESCRIPTION
#### What is the purpose of this pull request?
* Fix pickup points list to only show more pickup points button if has more than minimum

#### What problem is this solving?
List would show two lists when pickup points where less than minimum of 3.

#### How should this be manually tested?
1. Add [items to cart](https://beta--vtexgame1.myvtex.com/checkout/cart/add?&workspace=beta&sku=298&qty=1&seller=1&sc=1)
2. Go to Shipping
3. Select Pickup tab
4. Search for `Praia de botafogo 300`
5. Pickup points should show normally.

#### Screenshots or example usage
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
