### PR TITLE
Fixed reference for permission status from state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Permission status from state which prevented users from select geolocation
+
 ## [3.0.3] - 2019-09-09
 
 ### Fixed

--- a/react/Geolocation.js
+++ b/react/Geolocation.js
@@ -64,8 +64,9 @@ class Geolocation extends Component {
 
   handleGetCurrentPosition = () => {
     const { activeState, setGeolocationStatus } = this.props
+    const { permissionStatus } = this.state
 
-    switch (permission.state) {
+    switch (permissionStatus) {
       case DENIED:
         this.getCurrentPositionError({ code: 1 })
         break

--- a/react/ModalState.js
+++ b/react/ModalState.js
@@ -105,7 +105,8 @@ class ModalState extends Component {
     if (
       (this.state.localSearching &&
         isCurrentState(SEARCHING, activeSidebarState)) ||
-      isCurrentState('', activeSidebarState)
+      isCurrentState('', activeSidebarState) ||
+      isCurrentState(ERROR_NOT_FOUND, activeState)
     ) {
       return
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?
### Fixed

- Permission status from state which prevented users from select geolocation

#### What problem is this solving?
https://app.clubhouse.io/vtex-dev/story/13494/comportamento-melhorado-na-rela%C3%A7%C3%A3o-entre-mapa-e-lista

#### How should this be manually tested?
1. Add [items to cart](https://beta--vtexgame1.myvtex.com/checkout/cart/add?&workspace=beta&sku=298&qty=1&seller=1&sc=1)
2. Go to Shipping
3. Select Pickup tab
4. Click on Search pickup points with geolocation
5. Modal should search normally

#### Screenshots or example usage
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
