### PR TITLE
Fixed unavailable items amount which previously showed wrongly the items amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Unavailable items amount which previously showed wrongly the items amount
+
 ## [3.0.4] - 2019-09-09
 
 ### Fixed

--- a/react/components/PickupPointInfo.js
+++ b/react/components/PickupPointInfo.js
@@ -166,8 +166,7 @@ class PickupPointInfo extends Component {
                   styles.pickupPointAvailability
                 } pkpmodal-pickup-point-availability`}>
                 {translate(intl, 'unavailableItemsAmount', {
-                  unavailableItemsAmount: unavailableItemsAmount,
-                  itemsAmount: items.length,
+                  itemsAmount: unavailableItemsAmount,
                 })}
               </span>
             )}

--- a/react/components/ProductItems.css
+++ b/react/components/ProductItems.css
@@ -7,6 +7,8 @@
   display: inline-block;
   margin: 4px 8px 4px 0;
   padding: 2px;
+  height: 50px;
+  width: 50px;
 }
 
 .productItemUnavailable {


### PR DESCRIPTION
#### What is the purpose of this pull request?
* Fixed unavailable items amount which previously showed wrongly the items amount

#### What problem is this solving?
Previously the list showed the wrong quantity of unavailable items 

#### How should this be manually tested?
1. Add [items to cart](https://fernando--tokstok.myvtex.com/checkout/cart/add?&workspace=fernando&sku=348830&qty=1&seller=1&sc=1&sku=334727&qty=1&seller=1&sc=1)
2. Go to Shipping and then click the Pickup tab
3. Search for `Praia de botafogo`
4. The list should show the right number of unavailable items

#### Screenshots or example usage
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
