### PR TITLE
Fix/pickups order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Best pickups algorithm, it was returning score as NaN resulting in wrong order;
+- Best pickup markers since it was counting only the first pickup point.
+
 ## [3.0.5] - 2019-09-09
 
 ### Fixed
 
-- Unavailable items amount which previously showed wrongly the items amount
+- Unavailable items amount which previously showed wrongly the items amount.
 
 ## [3.0.4] - 2019-09-09
 
 ### Fixed
 
-- Permission status from state which prevented users from select geolocation
+- Permission status from state which prevented users from select geolocation.
 
 ## [3.0.3] - 2019-09-09
 
 ### Fixed
 
-- Pickups list to only show button if has more than three pickup points
+- Pickups list to only show button if has more than three pickup points.
 
 ## [3.0.2] - 2019-09-09
 

--- a/react/components/Map.js
+++ b/react/components/Map.js
@@ -468,7 +468,7 @@ class Map extends Component {
           const markerIconImage =
             index < BEST_PICKUPS_AMOUNT &&
             bestPickupOptions.length > BEST_PICKUPS_AMOUNT &&
-            this.markers.length === 0
+            this.markers.length < BEST_PICKUPS_AMOUNT
               ? bestMarkerIcon
               : markerIcon
           const isScaledMarker =
@@ -581,7 +581,9 @@ class Map extends Component {
         })
         setSelectedPickupPoint({
           pickupPoint: pickupPointsList ? pickupPointsList[index] : pickupPoint,
-          isBestPickupPoint: index < BEST_PICKUPS_AMOUNT,
+          isBestPickupPoint: pickupPointsList
+            ? false
+            : index < BEST_PICKUPS_AMOUNT,
         })
         updateLocationTab(HIDE_MAP)
         setShouldSearchArea(false)


### PR DESCRIPTION
#### What is the purpose of this pull request?
### Fixed

- Best pickups algorithm, it was returning score as NaN resulting in wrong order;
- Best pickup markers since it was counting only the first pickup point.

#### How should this be manually tested?
1. Add [items to cart](https://fernando--drimjuguetes.myvtex.com/checkout/cart/add?&workspace=fernando&sku=63525&qty=1&seller=1&sc=1)
2. Go to Shipping
3. Select Pickup tab
4. Search for `barcelona`
5. Pickup points should show in the right order.

#### Screenshots or example usage
n/a

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
