### PR TITLE
Fixes best pickups order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pickup points order since before it was sorting strings and sometime it would give different results.
+
 ## [3.0.6] - 2019-09-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Pickup points order since before it was sorting strings and sometime it would give different results.
+- Pickup points order by strings now by floating point number.
 
 ## [3.0.6] - 2019-09-09
 

--- a/react/utils/bestPickups.js
+++ b/react/utils/bestPickups.js
@@ -108,7 +108,7 @@ function calculatePickupPointsScore({ calcParams, pickupOptions }) {
 
     return {
       ...pickup,
-      score: points.toFixed(2),
+      score: parseFloat(points.toFixed(2)),
     }
   })
 


### PR DESCRIPTION
#### What is the purpose of this pull request?


#### What problem is this solving?
### Fixed
- Pickup points order since before it was sorting strings and sometime it would give different results.

#### How should this be manually tested?
1. Visit [cart](https://fernando--imaginarium.myvtex.com/checkout/?orderFormId=5f6994c2d62449ae9ccd2c3d43f28760#/shipping)
2. Go to Shipping
3. Open Pickup points modal
4. Pickups should be sorted as their correct score

#### Screenshots or example usage
n/a
#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
