### PR TITLE
Fixes searching on mobile through the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Searching on mobile through the map would return list mode.
+
 ## [3.0.7] - 2019-09-10
 
 ### Fixed

--- a/react/PickupPointsModal.js
+++ b/react/PickupPointsModal.js
@@ -39,6 +39,7 @@ class PickupPointsModal extends Component {
       mapStatus: HIDE_MAP,
       isLargeScreen: window.innerWidth > 1023,
       shouldUseMaps: !!props.googleMapsKey,
+      innerWidth: window.innerWidth,
     }
   }
 
@@ -71,10 +72,14 @@ class PickupPointsModal extends Component {
   }
 
   resize = debounce(() => {
-    if (!this.state.isMounted) return
+    // On mobile browsers trigger the resize event when keyboard is opened
+    // even though the screen size itself is the same
+    const isWidthEqual = this.state.innerWidth === window.innerWidth
+    if (!this.state.isMounted || isWidthEqual) return
     this.setState({
       isLargeScreen: window.innerWidth > 1023,
       mapStatus: window.innerWidth > 1023 ? SHOW_MAP : HIDE_MAP,
+      innerWidth: window.innerWidth,
     })
   }, 200)
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
### Fixed

- Searching on mobile through the map would return list mode.

#### What problem is this solving?
When searching in the address input on mobile through the map state, the search would always return to list state instead of map.

#### How should this be manually tested?
1. Add [items to cart](https://fernando--vtexgame1.myvtex.com/checkout/cart/add?&workspace=fernando&sku=298&qty=1&seller=1&sc=1) on a mobile device
2. Go to shipping and select pickup points tabs
3. Search for `Praia de botafogo 300`
4. Select `Map` tab
5. Search `Praia de botafogo 316` and it should stay in the map state.

#### Screenshots or example usage
n/a
#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
