### PR TITLE
Fix shippingData request by including missing itemIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `shippingData` request adding missing `itemIndex` from the body.
+
 ## [3.0.9] - 2019-09-11
 
-## Fixed
+### Fixed
 
 - Map breaking if did not find bounds.
 

--- a/react/fetchers/index.js
+++ b/react/fetchers/index.js
@@ -61,6 +61,7 @@ export function updateShippingData(logisticsInfo, pickupPoint) {
     logisticsInfo: logisticsInfo.map(li => {
       const hasSla = li.slas.some(sla => sla.id === pickupPoint.id)
       return {
+        itemIndex: li.itemIndex,
         addressId: hasSla ? pickupAddressWithAddressId.addressId : li.addressId,
         selectedSla: hasSla ? pickupPoint.id : li.selectedSla,
         selectedDeliveryChannel: hasSla


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fix shippingData request by including missing itemIndex

#### What problem is this solving?
Request would return with error `400` due to the missing `itemIndex`

#### How should this be manually tested?
1. Add [items to cart](https://fernando--vtexgame1.myvtex.com/checkout/cart/add?&workspace=fernando&sku=31&qty=1&seller=1&sc=1&sku=298&qty=1&seller=1&sc=1)
#### Screenshots or example usage
n/a
#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
