### PR TITLE
Fix external pickup point matching with simulation SLAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- check if simulation SLA contains `pickupPointId` from the selected pickup point
+
 ## [3.0.10] - 2019-09-12
 
 ### Fixed

--- a/react/utils/SlasUtils.js
+++ b/react/utils/SlasUtils.js
@@ -19,9 +19,15 @@ export function isPickup(deliveryChannelSource) {
 }
 
 export function findSla(li, pickupPoint) {
-  return li.slas.find(simulationPickupPoint =>
-    simulationPickupPoint.id.includes(
-      pickupPoint && (pickupPoint.id || pickupPoint.pickupPointId)
-    )
+  return li.slas.find(
+    simulationPickupPoint =>
+      (simulationPickupPoint.id &&
+        simulationPickupPoint.id.includes(
+          pickupPoint && (pickupPoint.id || pickupPoint.pickupPointId)
+        )) ||
+      (simulationPickupPoint.pickupPointId &&
+        simulationPickupPoint.pickupPointId.includes(
+          pickupPoint && (pickupPoint.id || pickupPoint.pickupPointId)
+        ))
   )
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fix external pickup point matching with simulation SLAs

#### What problem is this solving?
Some external pickup points would not match with de result simulation pickup points, resulting in a available pickup point to be shown as unavailable.

#### How should this be manually tested?
1. Visit [cart with workspace](https://fernando--cobasi.myvtex.com/checkout/?orderFormId=8b28bf221f1e416fbf535c6670d36904#/cart)
#### Screenshots or example usage
n/a
#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
