### PR TITLE
HOTFIX Fixed geolocation stuck on loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Geolocation stuck on loading
+- Getting pickup points from simulation
+
 ## [3.0.13] - 2019-09-13
 
 ### Added

--- a/react/Geolocation.js
+++ b/react/Geolocation.js
@@ -63,26 +63,17 @@ class Geolocation extends Component {
   }
 
   handleGetCurrentPosition = () => {
-    const { activeState, setGeolocationStatus } = this.props
+    const { setGeolocationStatus } = this.props
     const { permissionStatus } = this.state
-
     switch (permissionStatus) {
       case DENIED:
         this.getCurrentPositionError({ code: 1 })
         break
 
       case GRANTED:
-        setGeolocationStatus(SEARCHING)
-        if (activeState === SIDEBAR) {
-          this.props.setActiveSidebarState(SEARCHING)
-        } else {
-          this.props.setActiveState(SEARCHING)
-        }
-
-        this.handleCurrentPosition()
-        break
-
       default:
+        setGeolocationStatus(SEARCHING)
+        this.setCurrentActiveState(SEARCHING)
         this.handleCurrentPosition()
     }
   }

--- a/react/ModalState.js
+++ b/react/ModalState.js
@@ -160,7 +160,10 @@ class ModalState extends Component {
       isCurrentState(DETAILS, activeSidebarState) && !selectedPickupPoint
 
     const isSidebarState =
-      !isSearching && hasPickups && isCurrentState(SEARCHING, activeState)
+      !isSearching &&
+      hasPickups &&
+      (isCurrentState(SEARCHING, activeState) ||
+        isCurrentState(GEOLOCATION_SEARCHING, activeState))
 
     const isListState =
       !isSearching &&
@@ -178,12 +181,6 @@ class ModalState extends Component {
       !isCurrentState(GEOLOCATION_SEARCHING, activeState)
 
     switch (true) {
-      case isGeolocationSearchingState:
-        if (activeState === GEOLOCATION_SEARCHING) return
-        this.setActiveState(GEOLOCATION_SEARCHING)
-        this.setActiveSidebarState(LIST)
-        return
-
       case isListState:
         if (activeSidebarState === LIST) return
         this.setActiveSidebarState(LIST)
@@ -192,6 +189,12 @@ class ModalState extends Component {
       case isSidebarState:
         if (activeState === SIDEBAR) return
         this.setActiveState(SIDEBAR)
+        this.setActiveSidebarState(LIST)
+        return
+
+      case isGeolocationSearchingState:
+        if (activeState === GEOLOCATION_SEARCHING) return
+        this.setActiveState(GEOLOCATION_SEARCHING)
         this.setActiveSidebarState(LIST)
         return
 
@@ -302,8 +305,12 @@ class ModalState extends Component {
       orderFormId,
       pickupAddress,
     })
-      .then(data =>
-        this.updatePickupPoints({ data, pickupPoint, isBestPickupPoint })
+      .then(response =>
+        this.updatePickupPoints({
+          data: response.data,
+          pickupPoint,
+          isBestPickupPoint,
+        })
       )
       .catch(error => {
         this.setState(
@@ -336,7 +343,7 @@ class ModalState extends Component {
       orderFormId,
       pickupAddress: newAreaAddress,
     })
-      .then(data => this.updatePickupPoints({ data }))
+      .then(response => this.updatePickupPoints({ data: response.data }))
       .catch(error => {
         this.setActiveSidebarState(LIST)
         this.setState({ localSearching: false })


### PR DESCRIPTION
#### What is the purpose of this pull request?

### Fixed

- Geolocation stuck on loading
- Getting pickup points from simulation

#### How should this be manually tested?
1. Add [items to cart](http://vtexchileqa.myvtex.com/checkout/cart/add?sku=951&seller=1)
2. Simulate chrome with lat -33.4091162 / long -70.5688018
3. Select Pickup tab
4. Click to use geolocation

#### Screenshots or example usage
n/a

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
