### PR TITLE
Fixes duplicate available and external pickup points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Showing availability only if not an external pickup point
+
+### Changed
+
+- External pickup points to show only the ones which are not SLAs
+
 ## [3.0.14] - 2019-09-13
 
 ### Fixed

--- a/react/ModalState.js
+++ b/react/ModalState.js
@@ -353,6 +353,7 @@ class ModalState extends Component {
   updatePickupPoints = ({ data, pickupPoint, isBestPickupPoint }) => {
     const {
       bestPickupOptions,
+      externalPickupPoints,
       logisticsInfo,
       pickupOptions,
       pickupPoints,
@@ -375,6 +376,13 @@ class ModalState extends Component {
     const newPickupPoints = getUniquePickupPoints(
       pickupPoints,
       availablePickupPoints
+    )
+
+    const newExternalPickupPoints = externalPickupPoints.filter(
+      externalPickup =>
+        !newBestPickupOptions.some(
+          option => option.pickupPointId === externalPickup.id
+        )
     )
 
     const newLogisticsInfo = logisticsInfo.map((li, index) => ({
@@ -403,6 +411,7 @@ class ModalState extends Component {
             sortBy(newPickupOptions, 'pickupDistance')
           ),
           bestPickupOptions: this.removePickupDistance(newBestPickupOptions),
+          externalPickupPoints: newExternalPickupPoints,
           logisticsInfo: newLogisticsInfo,
         },
         () => this.setActiveSidebarState(DETAILS)
@@ -417,6 +426,7 @@ class ModalState extends Component {
             sortBy(newPickupOptions, 'pickupDistance')
           ),
           bestPickupOptions: this.removePickupDistance(newBestPickupOptions),
+          externalPickupPoints: newExternalPickupPoints,
           logisticsInfo: newLogisticsInfo,
         },
         () =>
@@ -436,15 +446,22 @@ class ModalState extends Component {
   }
 
   getExternalPickupOptions = geoCoordinates => {
-    const { externalPickupPoints } = this.state
+    const { bestPickupOptions, externalPickupPoints } = this.state
 
     fetchExternalPickupPoints(geoCoordinates)
       .then(data =>
         this.setState({
-          externalPickupPoints: data.items.map(item => ({
-            ...item.pickupPoint,
-            distance: null,
-          })),
+          externalPickupPoints: data.items
+            .filter(
+              item =>
+                !bestPickupOptions.some(
+                  option => option.pickupPointId === item.pickupPoint.id
+                )
+            )
+            .map(item => ({
+              ...item.pickupPoint,
+              distance: null,
+            })),
         })
       )
       .catch(() => this.setState({ externalPickupPoints }))

--- a/react/components/PickupPointInfo.js
+++ b/react/components/PickupPointInfo.js
@@ -90,15 +90,19 @@ class PickupPointInfo extends Component {
       storePreferencesData,
     })
 
-    const shouldShowUnavailableAmount =
-      unavailableItemsAmount !== items.length && unavailableItemsAmount > 0
-
     const sholdShowUnavailableMarker = !isList && !pickupPoint.pickupStoreInfo
     const sholdShowSearchMarker = isList && !pickupPoint.pickupStoreInfo
     const shouldShowEstimate = pickupPoint && pickupPoint.shippingEstimate
     const isBestPickupPointAndAvailable =
       pickupPoint.pickupStoreInfo &&
       (isBestPickupPoint || (isSelectedBestPickupPoint && !isList))
+    const shouldShowUnavailableAmount =
+      unavailableItemsAmount !== items.length &&
+      unavailableItemsAmount > 0 &&
+      !sholdShowSearchMarker
+
+    const shouldShowAllUnavailable =
+      unavailableItemsAmount === items.length && !sholdShowSearchMarker
 
     return (
       <div
@@ -151,7 +155,7 @@ class PickupPointInfo extends Component {
               />
             </div>
 
-            {unavailableItemsAmount === items.length && (
+            {shouldShowAllUnavailable && (
               <span
                 className={`${
                   styles.pickupPointNoneAvailable


### PR DESCRIPTION
#### What is the purpose of this pull request?
### Fixed

- Showing availability only if not an external pickup point

### Changed

- External pickup points to show only the ones which are not SLAs


#### What problem is this solving?
Pickup modal showed duplicate pickup points one available and another unavailable, also pickup points which are for search should no show availability.

#### How should this be manually tested?
1. Add [items to cart](https://fernando--deguns.myvtex.com/checkout/cart/add?&workspace=fernando&sku=1677&qty=1&seller=1&sc=1&sku=15123&qty=1&seller=1&sc=1)
2. Go to shipping and select Pickup tab
3. Search for `Worcester, MA`
4. Available pickup points should not be duplicates anymore.
5. Also, searching in the area, pickup points which were to be searched are not duplicated anymore after they turn into available pickup point.

#### Screenshots or example usage
n/a
#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
