### PR TITLE
Fixed Modal breaking if map does not load due to billing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Modal breaking if map does not load due to billing issues
+
 ## [3.0.16] - 2019-10-02
 
 ### Fixed

--- a/react/components/Map.js
+++ b/react/components/Map.js
@@ -604,7 +604,9 @@ class Map extends Component {
     const { googleMaps } = this.props
 
     marker.setIcon({
-      url: isSearching ? searchingMarkerIcon : marker.icon.url,
+      url: isSearching
+        ? searchingMarkerIcon
+        : marker && marker.icon && marker.icon.url,
       size: new googleMaps.Size(width, height),
       scaledSize: new googleMaps.Size(width, height),
     })


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Fixed Modal breaking if map does not load due to billing issues

#### How should this be manually tested?
1. Add [items to cart](https://fernando--cobasi.myvtex.com/checkout/cart/add?&workspace=fernando&sku=941077&qty=1&seller=1&sc=1&sku=765899&qty=1&seller=1&sc=1&sku=782246&qty=1&seller=1&sc=1)
2. Go to Shipping and type postal code `01010010`
3. Go to pickup and open pickup points modal
4. Browsing through pickup points should not break the modal.

#### Screenshots or example usage
n/a
#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
