### PR TITLE
Fixes not showing best pickup point markers in the remaining pickup points list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Not showing best pickup point markers in the remaining pickup points list
+
 ## [3.0.17] - 2019-10-03
 
 ### Fixed

--- a/react/components/PickupPointsList.js
+++ b/react/components/PickupPointsList.js
@@ -17,27 +17,34 @@ class PickupPointsList extends PureComponent {
 
     this.state = {
       pickupPoints: [...props.pickupOptions, ...props.externalPickupPoints],
+      bestPickupOptions: props.bestPickupOptions.slice(0, BEST_PICKUPS_AMOUNT),
       currentPickupPoints: [
         ...props.pickupOptions,
         ...props.externalPickupPoints,
-      ].filter((_, index) => index < 20),
+      ].slice(0, 20),
       currentAmount: 20,
     }
   }
 
   componentDidUpdate(prevProps) {
-    const { pickupOptions, externalPickupPoints } = this.props
+    const {
+      bestPickupOptions,
+      externalPickupPoints,
+      pickupOptions,
+    } = this.props
+
     const { currentAmount } = this.state
+
     if (
       pickupOptions !== prevProps.pickupOptions ||
       externalPickupPoints !== prevProps.externalPickupPoints
     ) {
       const pickupPoints = [...pickupOptions, ...externalPickupPoints]
+
       this.setState({
         pickupPoints,
-        currentPickupPoints: pickupPoints.filter(
-          (_, index) => index < currentAmount
-        ),
+        bestPickupOptions: bestPickupOptions.slice(0, BEST_PICKUPS_AMOUNT),
+        currentPickupPoints: pickupPoints.slice(0, currentAmount),
       })
     }
   }
@@ -59,7 +66,6 @@ class PickupPointsList extends PureComponent {
 
   render() {
     const {
-      bestPickupOptions,
       logisticsInfo,
       items,
       intl,
@@ -72,12 +78,16 @@ class PickupPointsList extends PureComponent {
       storePreferencesData,
     } = this.props
 
-    const { currentAmount, currentPickupPoints, pickupPoints } = this.state
+    const {
+      bestPickupOptions,
+      currentAmount,
+      currentPickupPoints,
+      pickupPoints,
+    } = this.state
 
     const hasMorePickupPoints = currentAmount <= pickupPoints.length
 
-    const hasMinimumPickupPoints =
-      bestPickupOptions.length > BEST_PICKUPS_AMOUNT
+    const hasMinimumPickupPoints = pickupPoints.length > BEST_PICKUPS_AMOUNT
 
     const showOtherList = hasMinimumPickupPoints && showOtherPickupPoints
 
@@ -90,30 +100,28 @@ class PickupPointsList extends PureComponent {
             <p className={styles.pickupListTitle}>
               {translate(intl, 'bestResults')}
             </p>
-            {bestPickupOptions
-              .filter((_, index) => index < BEST_PICKUPS_AMOUNT)
-              .map(pickupPoint => (
-                <div
-                  className={`${
-                    styles.pointsItem
-                  } pkpmodal-points-item best-pickupPoint-${pickupPoint.id}`}
-                  key={`best-pickupPoint-${pickupPoint.id}`}>
-                  <PickupPointInfo
-                    isList
-                    isBestPickupPoint
-                    items={items}
-                    logisticsInfo={logisticsInfo}
-                    pickupPoint={pickupPoint}
-                    pickupPointId={pickupPoint.id}
-                    selectedRules={rules}
-                    sellerId={sellerId}
-                    setActiveSidebarState={setActiveSidebarState}
-                    setSelectedPickupPoint={setSelectedPickupPoint}
-                    shouldUseMaps={shouldUseMaps}
-                    storePreferencesData={storePreferencesData}
-                  />
-                </div>
-              ))}
+            {bestPickupOptions.map(pickupPoint => (
+              <div
+                className={`${
+                  styles.pointsItem
+                } pkpmodal-points-item best-pickupPoint-${pickupPoint.id}`}
+                key={`best-pickupPoint-${pickupPoint.id}`}>
+                <PickupPointInfo
+                  isList
+                  isBestPickupPoint
+                  items={items}
+                  logisticsInfo={logisticsInfo}
+                  pickupPoint={pickupPoint}
+                  pickupPointId={pickupPoint.id}
+                  selectedRules={rules}
+                  sellerId={sellerId}
+                  setActiveSidebarState={setActiveSidebarState}
+                  setSelectedPickupPoint={setSelectedPickupPoint}
+                  shouldUseMaps={shouldUseMaps}
+                  storePreferencesData={storePreferencesData}
+                />
+              </div>
+            ))}
             {showOtherButton && (
               <Button
                 id="pkpmodal-show-list-btn"
@@ -151,7 +159,9 @@ class PickupPointsList extends PureComponent {
                   key={`pickupPoint-${pickupPoint.id}`}>
                   <PickupPointInfo
                     isList
-                    isBestPickupPoint={false}
+                    isBestPickupPoint={bestPickupOptions.some(
+                      localPickupPoint => localPickupPoint.id === pickupPoint.id
+                    )}
                     items={items}
                     logisticsInfo={logisticsInfo}
                     pickupPoint={pickupPoint}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes not showing best pickup point markers in the remaining pickup points list

#### What problem is this solving?
Closes [story](https://app.clubhouse.io/vtex/story/23520/marcadores-de-pickup-points-com-destaque-n%C3%A3o-s%C3%A3o-exibidos-na-lista-completa-por-dist%C3%A2ncia)

#### How should this be manually tested?
1. Add [items to cart]()
2. Search for pickup points in `Barcelona`
3. Click to see all pickup points
4. Best pickup points should show the star markers

#### Screenshots or example usage
|Before|
|-|
|![Screen Shot 2019-10-15 at 19 09 06](https://user-images.githubusercontent.com/5608421/66873619-45a77c00-ef7f-11e9-9fb9-df5b360a9e56.png)|

|After|
|-|
|![Screen Shot 2019-10-15 at 19 08 33](https://user-images.githubusercontent.com/5608421/66873652-5a840f80-ef7f-11e9-9abc-61206d027aa4.png)|

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
