### PR TITLE
Fix showing unavailable pickup items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Showing pickup unavailable items.
+
 ## [3.0.20] - 2019-10-28
 
 ### Added
+
 - Add German translations.
 
 ## [3.0.19] - 2019-10-24

--- a/react/fetchers/index.js
+++ b/react/fetchers/index.js
@@ -70,9 +70,9 @@ export function updateShippingData(logisticsInfo, pickupPoint) {
         itemIndex: li.itemIndex,
         addressId: hasSla ? pickupAddressWithAddressId.addressId : li.addressId,
         selectedSla: hasSla ? pickupPoint.id : li.selectedSla,
-        selectedDeliveryChannel: hasSla
-          ? PICKUP_IN_STORE
-          : li.selectedDeliveryChannel,
+        selectedDeliveryChannel: li.selectedSla
+          ? li.selectedDeliveryChannel
+          : null,
       }
     }),
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix showing unavailable pickup items

#### What problem is this solving?
Closes [thread](https://vtex.slack.com/archives/C6HS68DHD/p1579829813035200)

#### How should this be manually tested?
1. Add [items to cart](https://fernando--vtexgame1.myvtex.com/checkout/cart/add/?sku=307&qty=1&seller=1&sc=1&sku=331&qty=1&seller=1&sc=1)
4. Open the Pickup points modal and search for `Praia de botafogo 300`
3. Select `Flamengo` and the other item should be `unavailable`

#### Screenshots or example usage
n/a
#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
