### PR TITLE
Fixes selecting delivery channel for Delivery items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Selecting delivery channel for Delivery items.
+
 ## [3.0.21] - 2020-01-29
 
 ### Fixed

--- a/react/fetchers/index.js
+++ b/react/fetchers/index.js
@@ -2,6 +2,7 @@ import { newAddress } from '../utils/newAddress'
 import { PICKUP_IN_STORE, SEARCH } from '../constants'
 import axios from 'axios'
 import axiosRetry from 'axios-retry'
+import { isDelivery } from '../utils/DeliveryChannelsUtils'
 
 axiosRetry(axios, { retries: 2 })
 
@@ -66,13 +67,17 @@ export function updateShippingData(logisticsInfo, pickupPoint) {
     selectedAddresses: [pickupAddressWithAddressId],
     logisticsInfo: logisticsInfo.map(li => {
       const hasSla = li.slas.some(sla => sla.id === pickupPoint.id)
+      const hasDeliverySla = li.slas.some(sla => isDelivery(sla))
+
       return {
         itemIndex: li.itemIndex,
         addressId: hasSla ? pickupAddressWithAddressId.addressId : li.addressId,
         selectedSla: hasSla ? pickupPoint.id : li.selectedSla,
-        selectedDeliveryChannel: li.selectedSla
-          ? li.selectedDeliveryChannel
-          : null,
+        selectedDeliveryChannel: hasSla
+          ? PICKUP_IN_STORE
+          : hasDeliverySla
+            ? li.selectedDeliveryChannel
+            : null,
       }
     }),
   }

--- a/react/utils/DeliveryChannelsUtils.js
+++ b/react/utils/DeliveryChannelsUtils.js
@@ -1,0 +1,29 @@
+import isString from 'lodash/isString'
+import get from 'lodash/get'
+import { PICKUP_IN_STORE, DELIVERY } from '../constants'
+
+function getDeliveryChannel(deliveryChannelSource) {
+  if (isString(deliveryChannelSource)) {
+    return deliveryChannelSource
+  }
+  return (
+    get(deliveryChannelSource, 'deliveryChannel') ||
+    get(deliveryChannelSource, 'selectedDeliveryChannel') ||
+    get(deliveryChannelSource, 'id')
+  )
+}
+
+export function isCurrentChannel(deliveryChannelSource, currentChannel) {
+  const deliveryChannel = getDeliveryChannel(deliveryChannelSource)
+  return deliveryChannel === currentChannel
+}
+
+export function isPickup(deliveryChannelSource) {
+  const deliveryChannel = getDeliveryChannel(deliveryChannelSource)
+  return deliveryChannel === PICKUP_IN_STORE
+}
+
+export function isDelivery(deliveryChannelSource) {
+  const deliveryChannel = getDeliveryChannel(deliveryChannelSource)
+  return deliveryChannel === DELIVERY
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes selecting delivery channel for Delivery items.

#### What problem is this solving?
Closes [story](https://app.clubhouse.io/vtex/story/30705/usu%C3%A1rio-preso-no-checkout-se-item-indispon%C3%ADvel-para-pickup-selecionado-e-delivery).

#### How should this be manually tested?
1. Add [items to cart](https://fernando--paguemenos.myvtex.com/checkout/cart/add/?sku=49307&qty=1&seller=1&sc=1&sku=48216&qty=1&seller=1&sc=1&sku=37836&qty=1&seller=1&sc=1&sku=28633&qty=1&seller=1&sc=1&sku=27567&qty=1&seller=1&sc=1&sku=55317&qty=1&seller=1&sc=1&sku=54944&qty=1&seller=1&sc=1&sku=54547&qty=1&seller=1&sc=1&sku=40118&qty=1&seller=1&sc=1&sku=51351&qty=1&seller=1&sc=1&sku=41944&qty=1&seller=1&sc=1&sku=55014&qty=1&seller=1&sc=1&sku=47549&qty=1&seller=1&sc=1&sku=52920&qty=1&seller=1&sc=1&sku=49096&qty=1&seller=1&sc=1&sku=52532&qty=1&seller=1&sc=1&sku=52844&qty=1&seller=1&sc=1&sku=48314&qty=1&seller=1&sc=1&sku=51561&qty=1&seller=1&sc=1&sku=54535&qty=1&seller=1&sc=1&sku=51855&qty=1&seller=1&sc=1&sku=54400&qty=1&seller=1&sc=1&sku=50556&qty=1&seller=1&sc=1&sku=10410&qty=1&seller=1&sc=1&sku=25715&qty=1&seller=1&sc=1);
2. Proceed to shipping and type postal code `60025-902`;
3. Toggle Pickup and select another pickup point;
4. You should be able to proceed to payment succesfully.

#### Screenshots or example usage
n/a
#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
