### PR TITLE
Fix modal breaking if an image URL doesn't match the regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Modal breaking if an image URL does not match the regex.
+
+### Changed
+
+- Regular expression used to get image dimensions.
+
 ## [3.0.22] - 2020-01-30
 
 ### Fixed

--- a/react/utils/Images.js
+++ b/react/utils/Images.js
@@ -2,12 +2,12 @@ const DEFAULT_WIDTH = 50
 const DEFAULT_HEIGHT = 50
 const DEFAULT_HDF = 1
 
-const baseUrlRegex = new RegExp(/.+ids\/(\d+)(?:-(\d+)-(\d+)|)\//)
+const baseUrlRegex = new RegExp(/.+ids\/(\d+)[a-zA-Z]+(?:-(\d+)-(\d+)|)\//)
 const sizeRegex = new RegExp(/-(\d+)-(\d+)/)
 
 function cleanImageUrl(imageUrl) {
   let resizedImageUrl = imageUrl
-  const result = baseUrlRegex.exec(imageUrl)
+  const result = baseUrlRegex.exec(imageUrl) || []
   if (result.length > 0) {
     if (
       result.length === 4 &&

--- a/react/utils/Images.js
+++ b/react/utils/Images.js
@@ -2,7 +2,7 @@ const DEFAULT_WIDTH = 50
 const DEFAULT_HEIGHT = 50
 const DEFAULT_HDF = 1
 
-const baseUrlRegex = new RegExp(/.+ids\/(\d+)[a-zA-Z]+(?:-(\d+)-(\d+)|)\//)
+const baseUrlRegex = new RegExp(/.+ids\/([a-zA-Z0-9]+)(?:-(\d+)-(\d+)|)\//)
 const sizeRegex = new RegExp(/-(\d+)-(\d+)/)
 
 function cleanImageUrl(imageUrl) {

--- a/react/utils/__tests__/image.test.js
+++ b/react/utils/__tests__/image.test.js
@@ -1,0 +1,21 @@
+import { fixImageUrl } from '../Images'
+
+describe('fixImageUrl', () => {
+  it('should return the resized image URL', () => {
+    const baseUrl = '//omniera.vteximg.com.br/arquivos/ids'
+
+    const cleanedImage = fixImageUrl(
+      `http:${baseUrl}/155401-135-135/CAN-09-04--1-.jpg`
+    )
+    const cleanedImage2 = fixImageUrl(
+      `http:${baseUrl}/ahsuh155401as-135-135/CAN-09-04--1-.jpg`
+    )
+    const cleanedImage3 = fixImageUrl(
+      `http:${baseUrl}/155sdsdsd401-135-135/CAN-09-04--1-.jpg`
+    )
+
+    expect(cleanedImage).toBe(`${baseUrl}/155401-50-50`)
+    expect(cleanedImage2).toBe(`${baseUrl}/ahsuh155401as-50-50`)
+    expect(cleanedImage3).toBe(`${baseUrl}/155sdsdsd401-50-50`)
+  })
+})


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR adds a fix to the situation where the product image URL is not accepted by the regex used to get the image dimensions info. 

The used regex did not accept URLs containing letters around the dimensions info like the following:  .../233609421632**e**-90-90/...

To solve that we are changing the regex to accept letters too. 

Also, this PR prevents the modal from breaking if, in the future, another URL does not match the regex.

<!--- Describe your changes in detail. -->

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Proceed to the [workspace](https://jeff--learnvtex.myvtex.com/checkout/cart/add/?sku=57&qty=1&seller=1&sc=1)
- Proceed to checkout
- Insert any email
- Insert name, last name, and a valid phone number (e.g. 9549876543)
- Proceed to shipping
- Change it to Pick up in point
- Search for an address manually
- Use the address Schenectady, NY, USA
- Pick Store 02 

Then it should look as the image below

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/76020345-019f1e80-5f02-11ea-9a29-0a0de5617bd2.png)


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
