### PR TITLE
[CHK-903] Fixes geolocation error fallback state + misc geolocation adjustments and metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Increase geolocation timeout to 10s
+- Change geolocation error modal state to the initial, search state, with an added error message.
 
 ## [3.5.1] - 2021-10-13
+### Changed
+- Increase geolocation timeout to 6s
 
 ## [3.5.0] - 2021-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Metrics for when the modal is closed while geolocation is loading
+- Metrics for the time it takes for geolocation to load
+
 ### Changed
 - Increase geolocation timeout to 10s
-- Change geolocation error modal state to the initial, search state, with an added error message.
+- Change geolocation error modal state to the initial search state, with an added error message.
+
+### Fixed
+- Prevent the modal from updating address etc. after the modal has been closed (at least a scenario where this happens).
 
 ## [3.5.1] - 2021-10-13
 ### Changed

--- a/react/Geolocation.js
+++ b/react/Geolocation.js
@@ -101,7 +101,7 @@ class Geolocation extends Component {
 
   handleCurrentPosition = () => {
     this.setState({ isLoadingGeolocation: true })
-    if(this.props.googleMaps) {
+    if (this.props.googleMaps) {
       this.unsubscribeGetCurrentPosition = getCurrentPosition(
         this.getCurrentPositionSuccess,
         this.getCurrentPositionError

--- a/react/Geolocation.js
+++ b/react/Geolocation.js
@@ -116,7 +116,7 @@ class Geolocation extends Component {
       case 0: // UNKNOWN ERROR
         setAskForGeolocation(false)
         setGeolocationStatus(ERROR_COULD_NOT_GETLOCATION)
-        this.setCurrentActiveState(ERROR_COULD_NOT_GETLOCATION)
+        this.setCurrentActiveState(INITIAL)
         searchPickupAddressByGeolocationEvent({
           confirmedGeolocation: true,
           browserError: true,
@@ -134,26 +134,20 @@ class Geolocation extends Component {
       case 2: // POSITION_UNAVAILABLE
         setAskForGeolocation(false)
         setGeolocationStatus(ERROR_NOT_FOUND)
-        this.setCurrentActiveState(ERROR_NOT_FOUND)
+        this.setCurrentActiveState(INITIAL)
         searchPickupAddressByGeolocationEvent({
           confirmedGeolocation: true,
           positionUnavailable: true,
         })
         break
       case 3: // TIMEOUT
-        // TODO#2: look into retrying timeout, refer to TODO#1
-        // Might be done either over there or here.
-
         setAskForGeolocation(false)
         setGeolocationStatus(ERROR_COULD_NOT_GETLOCATION)
-        this.setCurrentActiveState(ERROR_COULD_NOT_GETLOCATION)
-        // TODO#3: Log the user device, browser, etc, to study
-        // the causes of geolocation timing out more closely.
-
-        // Also the event below is likely erroneously named, timeouts
-        // don't seem to happen when the user dismisses, but when it
-        // takes too long for the GPS or similar to respond, or the
-        // device is blocking it for some reason.
+        this.setCurrentActiveState(INITIAL)
+        // The event below ("dismissedGeolocation") is likely erroneously named;
+        // error code 3 happens when the geolocation function takes too long
+        // to respond, for a number of reasons. Keeping the name though to
+        // avoid breaking things.
         searchPickupAddressByGeolocationEvent({ dismissedGeolocation: true })
         break
       default:

--- a/react/PickupPointsModal.js
+++ b/react/PickupPointsModal.js
@@ -265,7 +265,7 @@ class PickupPointsModal extends Component {
                 askForGeolocation={askForGeolocation}
                 googleMaps={googleMaps}
                 onChangeAddress={this.handleAddressChange}
-                onChangeisLoadingGeolocation={this.handleChangeGeolocationLoading}
+                onChangeGeolocationState={this.handleChangeGeolocationLoading}
                 rules={rules}>
                 <SearchArea
                   address={searchAddressWithAddressQuery}

--- a/react/components/EmptySearch.js
+++ b/react/components/EmptySearch.js
@@ -12,8 +12,20 @@ import styles from '../index.css'
 import emptyStyles from './EmptySearch.css'
 import { getShipsTo } from '../utils/AddressUtils'
 import GPSDenied from '../assets/components/GPSDenied'
-import { ERROR_NOT_ALLOWED } from '../constants'
+import { ERROR_COULD_NOT_GETLOCATION, ERROR_NOT_ALLOWED, ERROR_NOT_FOUND } from '../constants'
 import { injectState } from '../modalStateContext'
+
+const getGeolocationErrorMessage = (status) => {
+  switch (status) {
+    case ERROR_NOT_ALLOWED:
+      return 'askGeolocationDenied'
+    case ERROR_NOT_FOUND:
+    case ERROR_COULD_NOT_GETLOCATION:
+      return 'geolocationError'
+    default:
+      return null
+  }
+}
 
 class EmptySearch extends PureComponent {
   render() {
@@ -32,6 +44,8 @@ class EmptySearch extends PureComponent {
       setActiveState,
       shouldUseMaps,
     } = this.props
+
+    const geolocationErrorMessage = getGeolocationErrorMessage(geolocationStatus)
 
     return (
       <div className={`${styles.modalfullPage} pkpmodal-full-page`}>
@@ -72,10 +86,10 @@ class EmptySearch extends PureComponent {
             rules={rules}
             shipsTo={getShipsTo(intl, logisticsInfo)}
           />
-          {geolocationStatus === ERROR_NOT_ALLOWED && (
+          {geolocationErrorMessage && (
             <div className={emptyStyles.permissionDenied}>
               <GPSDenied />
-              <span>{translate(intl, 'askGeolocationDenied')}</span>
+              <span>{translate(intl, geolocationErrorMessage)}</span>
             </div>
           )}
         </div>

--- a/react/components/EmptySearch.js
+++ b/react/components/EmptySearch.js
@@ -21,7 +21,7 @@ const getGeolocationErrorMessage = (status) => {
       return 'askGeolocationDenied'
     case ERROR_NOT_FOUND:
     case ERROR_COULD_NOT_GETLOCATION:
-      return 'geolocationError'
+      return 'errorCouldNotGetLocation'
     default:
       return null
   }

--- a/react/utils/CurrentPosition.js
+++ b/react/utils/CurrentPosition.js
@@ -3,32 +3,14 @@ import { geolocationAutoCompleteAddress } from 'vtex.address-form/geolocationAut
 export function getCurrentPosition(successCallback, errorCallback) {
   return navigator.geolocation.getCurrentPosition(
     position => successCallback(position),
-    error => {
-      // TODO#1: retry in case of timeout, possibly with a lower accuracy.
-      // Not implementing right now because we might need to look into issues that long
-      // timeouts might cause, especially in terms of UX. But below is a suggestion:
-      /*
-      const TIMEOUT = 3
-      if (error.code === TIMEOUT ) {
-        navigator.geolocation.getCurrentPosition(successCallback, errorCallback, {
-          maximumAge: Infinity,
-          timeout: 20000,
-          enableHighAccuracy: false,
-        })
-      } else {
-        errorCallback(error)
-      }
-      */
-      errorCallback(error)
-    },
+    errorCallback,
     {
       maximumAge: Infinity,
-      // Increased timeout from 2000 to 6000.
-      // 2000 was timing out on my (@lbebber) machine, but increasing to ~5000 did the trick.
-      // Setting to 6000 for a balance between leaving a margin vs not waiting too much, but
-      // the ideal timeout value has to be looked into.
-      // Refer to TODO#3
-      timeout: 6000,
+      // getCurrentPosition timeout varies a lot depending on device,
+      // browser, and even user location. Avoid reducing this value,
+      // but if you do, track timeouts on a logging service.
+      // (currently, look for "dismissedGeolocation" on our kibana logs)
+      timeout: 10000,
       enableHighAccuracy: true,
     }
   )

--- a/react/utils/metrics.js
+++ b/react/utils/metrics.js
@@ -8,6 +8,8 @@ export function searchPickupAddressByGeolocationEvent(data) {
       deniedGeolocationPopUp: data.deniedGeolocation || false,
       positionUnavailable: data.positionUnavailable || false,
       browserError: data.browserError || false,
+      closedWhileLoading: data.closedWhileLoading || false,
+      elapsedTime: data.elapsedTime || 0,
     },
   })
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Mainly changes the geolocation error fallback state, allowing the user to input their own address instead of saying "there are no pickup points nearby".

Also increases the timeout of the getCurrentPosition function call, to hopefully decrease the number of times the geolocation fails.

Also adds metrics to track how long it takes generally for geolocation to work, how long it takes in failure scenarios, and to track if the user closes the modal while it is loading (to track if the timeout might be too long)

Also fixes post-unmount leaks.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

https://vtex-dev.atlassian.net/browse/CHK-903

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Testing this is very fiddly!

#### First, the main issue, which is the error state:

#### 1 - For the control case:
This workspace is based on the current `main`, only with the `getCurrentPosition` timeout set to 1ms to force-trigger the error.

Open it on an anonymous tab: https://lbebbercontrolpickuperror1--vtexgame1.myvtex.com/checkout/cart/add/?sku=307&qty=1&seller=1&sc=1

(If you are not in Rio de Janeiro, you might have to simulate the location via the Sensors tab on Chrome DevTools, for better testing)

Go through the checkout flow and try to find a pickup point based on your location. The error message that comes up should be along the lines of "there are no pickup points nearby", which is not true. After retrying (maybe a few times) though, the pickup points might come up.


https://user-images.githubusercontent.com/5691711/140183012-1378b885-e6e0-48da-b839-1ca2e77a493a.mov

<img width="910" alt="Screen Shot 2021-11-03 at 16 56 43" src="https://user-images.githubusercontent.com/5691711/140183474-715c8681-4c36-4311-98fd-b3360149d147.png">



#### 2 - For the test case which demonstrates the fix:
This workspace is based on this PR, but with the timeout also set as 1 to trigger the geolocation failure, in order to demonstrate the new error state.

Open on an anonymous tab https://lbebbertestpickuperror1--vtexgame1.myvtex.com/checkout/cart/add/?sku=307&qty=1&seller=1&sc=1

Following the same steps as the previous test, the modal should display the search field, along with an error message "error while getting the geolocation" or something of the sort.

https://user-images.githubusercontent.com/5691711/140184298-efdc871b-6f46-49f0-bbab-2a94af8d5b40.mov

<img width="913" alt="Screen Shot 2021-11-03 at 17 03 51" src="https://user-images.githubusercontent.com/5691711/140184446-368b2f18-9f2a-45b3-b30c-87e6b32cc332.png">

#### 3 - The actual PR code
...can be seen here https://lbebbertestpickup1--vtexgame1.myvtex.com/checkout/cart/add/?sku=307&qty=1&seller=1&sc=1, though whether it will trigger the error or not will depend on your device, browser, device and browser settings, location, and network conditions. However more likely than not it should work!

https://user-images.githubusercontent.com/5691711/140185078-cefc8f1b-a0b3-4a8e-b486-cf1dd356e7e2.mov

In this workspace, we can also test the logging. Close the modal before allowing the browser giving it your location, and you should see a log on the Network pane that sends `closedWhileLoading: true`, along with a `elapsedTime` metric


https://user-images.githubusercontent.com/5691711/140186020-295d4b59-fec1-412a-95bd-df16c140f110.mov

<img width="1240" alt="Screen Shot 2021-11-03 at 17 15 36" src="https://user-images.githubusercontent.com/5691711/140186243-9d45cfe4-c372-44f4-a892-4686587a07e4.png">


#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
