### PR TITLE
Disable holding ctrl to zoom on pickup points map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update map gesture handling to `"greedy"`.
+
 ### Fixed
 - Lint issues.
 

--- a/react/components/GoogleMap.tsx
+++ b/react/components/GoogleMap.tsx
@@ -69,6 +69,12 @@ interface Props {
    * @see {@type google.maps.Map['fitBounds']}
    */
   bounds?: google.maps.LatLngBounds | null
+  /**
+   * Type of gesture handling to be used for this map instance.
+   *
+   * @see {@type google.maps.MapOptions['gestureHandling']}
+   */
+  gestureHandling?: google.maps.MapOptions['gestureHandling']
 }
 
 /**
@@ -164,6 +170,7 @@ export const GoogleMap = forwardRef<GoogleMapRefObject, Props>(
       onClick,
       referenceCenter,
       bounds,
+      gestureHandling,
     },
     ref
   ) {
@@ -233,6 +240,7 @@ export const GoogleMap = forwardRef<GoogleMapRefObject, Props>(
         center: isGeoCoordinate(center)
           ? geoCoordinatesToLatLng(center)
           : undefined,
+        gestureHandling,
       })
 
       if (bounds) {

--- a/react/components/Map.jsx
+++ b/react/components/Map.jsx
@@ -148,6 +148,9 @@ class Map extends Component {
         referenceCenter={address.geoCoordinates.value}
         bounds={bounds}
         ref={this.mapRef}
+        // Disables holding ctrl to zoom, since this in a modal it does not
+        // affect the scrolling of the page and creates a better user experience
+        gestureHandling="greedy"
       >
         {children}
         <GoogleMarker


### PR DESCRIPTION
#### What is the purpose of this pull request?

Disables ctrl+zoom to zoom on the pickup points map. Now you should be able to zoom by using the scroll wheel on a mouse without needing to press ctrl.

#### What problem is this solving?

Better UX?

#### How should this be manually tested?

Linked on [paguemenos](https://lucas--paguemenos.myvtex.com/checkout/cart/add/?sku=19449&qty=1&seller=1&sc=1)

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
