### PR TITLE
[CHK-1935] Fix/pickup distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- Updates pickup points distances when changing the user location.
 - Lint issues.
 
 ## [3.7.0] - 2022-03-09

--- a/react/utils/GetString.js
+++ b/react/utils/GetString.js
@@ -1,7 +1,7 @@
 export function getPickupSlaString(slas) {
   return slas.reduce(
     (accumulatedString, currentPickupPoint) =>
-      currentPickupPoint.id ? accumulatedString + currentPickupPoint.id : '',
+      currentPickupPoint.id ? accumulatedString + currentPickupPoint.id + currentPickupPoint.pickupDistance : '',
     ''
   )
 }

--- a/react/utils/GetString.js
+++ b/react/utils/GetString.js
@@ -1,7 +1,11 @@
 export function getPickupSlaString(slas) {
   return slas.reduce(
     (accumulatedString, currentPickupPoint) =>
-      currentPickupPoint.id ? accumulatedString + currentPickupPoint.id + currentPickupPoint.pickupDistance : '',
+      currentPickupPoint.id
+        ? accumulatedString +
+          currentPickupPoint.id +
+          currentPickupPoint.pickupDistance
+        : '',
     ''
   )
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes issue where the pickup points distances would not update if the order of pickup points weren't changed.

<!--- Describe your changes in detail. -->

#### What problem is this solving?
Before:

https://user-images.githubusercontent.com/5691711/176902508-e02a13af-f90d-4bae-9209-7d938defa7e3.mov

After:

https://user-images.githubusercontent.com/5691711/176902731-085e11ce-db6e-4e51-8c22-d2c4e195ee69.mov

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

For the control case:

- Open https://vtexgame1.myvtex.com/checkout/cart/add/?sku=307&qty=1&seller=1&sc=1
- Click on "Calcular" to preview shipping options, and select "Pickup"
- Input the CEP 22250-040
- Mind the distances to the pickup points displayed--something around 1.3 and 1.9 km respectively
- Change the CEP to 22220-080
- The distances should stay the same

For the test case:
- Follow the same steps over on https://lbebber--vtexgame1.myvtex.com/checkout/cart/add/?sku=307&qty=1&seller=1&sc=1
- The distances should change as the user location changes

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
