### PR TITLE
CHK-1748: Fix address reset after field selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Address reset when inserted using levels configuration.
 
 ## [3.7.2] - 2022-07-12
 

--- a/react/components/SearchForm.js
+++ b/react/components/SearchForm.js
@@ -27,6 +27,14 @@ class SearchForm extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.address !== this.props.address) {
+      this.setState({
+        address: this.props.address,
+      })
+    }
+  }
+
   setMyLocationButtonVisibility = (visibility) => {
     this.setState({
       isMyLocationButtonVisible: visibility,

--- a/react/components/SearchForm.js
+++ b/react/components/SearchForm.js
@@ -49,6 +49,16 @@ class SearchForm extends Component {
     this.props.getCurrentPosition()
   }
 
+  componentDidUpdate(_, prevState) {
+    if (
+      this.state.address.postalCode?.value &&
+      this.state.address.postalCode.value !==
+        prevState.address.postalCode?.value
+    ) {
+      this.props.onChangeAddress(this.state.address)
+    }
+  }
+
   handleAddressChange = (address) => {
     this.setState((prevState) => ({
       address: {
@@ -56,10 +66,6 @@ class SearchForm extends Component {
         ...address,
       },
     }))
-
-    if (address.postalCode.value) {
-      this.props.onChangeAddress({ ...this.state.address, ...address })
-    }
   }
 
   render() {

--- a/react/components/SearchForm.js
+++ b/react/components/SearchForm.js
@@ -17,6 +17,21 @@ const { PostalCodeGetter, CountrySelector } = components
 const { GeolocationInput, DefaultInput } = inputs
 const { AddressShapeWithValidation } = shapes
 
+function compareGeoCoordinates(currentCoordinates, prevCoordinates) {
+  if (!currentCoordinates || currentCoordinates.length === 0) {
+    return false
+  }
+
+  if (!prevCoordinates || prevCoordinates.length === 0) {
+    return true
+  }
+
+  const [currentLat, currentLng] = currentCoordinates
+  const [prevLat, prevLng] = prevCoordinates
+
+  return currentLat !== prevLat || currentLng !== prevLng
+}
+
 class SearchForm extends Component {
   constructor(props) {
     super(props)
@@ -51,9 +66,13 @@ class SearchForm extends Component {
 
   componentDidUpdate(_, prevState) {
     if (
-      this.state.address.postalCode?.value &&
-      this.state.address.postalCode.value !==
-        prevState.address.postalCode?.value
+      (this.state.address.postalCode?.value &&
+        this.state.address.postalCode.value !==
+          prevState.address.postalCode?.value) ||
+      compareGeoCoordinates(
+        this.state.address.geoCoordinates?.value,
+        prevState.address.geoCoordinates?.value
+      )
     ) {
       this.props.onChangeAddress(this.state.address)
     }

--- a/react/components/SearchForm.js
+++ b/react/components/SearchForm.js
@@ -23,6 +23,7 @@ class SearchForm extends Component {
 
     this.state = {
       isMyLocationButtonVisible: true,
+      address: this.props.address,
     }
   }
 
@@ -48,9 +49,21 @@ class SearchForm extends Component {
     this.props.getCurrentPosition()
   }
 
+  handleAddressChange = (address) => {
+    this.setState((prevState) => ({
+      address: {
+        ...prevState.address,
+        ...address,
+      },
+    }))
+
+    if (address.postalCode.value) {
+      this.props.onChangeAddress({ ...this.state.address, ...address })
+    }
+  }
+
   render() {
     const {
-      address,
       googleMaps,
       Input,
       intl,
@@ -60,13 +73,14 @@ class SearchForm extends Component {
       isLoadingGoogle,
       isLoadingGeolocation,
       isSidebar,
-      onChangeAddress,
       rules,
       placeholder,
       setGeolocationFrom,
       shipsTo,
       permissionStatus,
     } = this.props
+
+    const { address } = this.state
 
     const geolocationStyle = `${styles.askGeolocationBtn} pkp-modal-ask-geolocation-btn`
 
@@ -95,7 +109,7 @@ class SearchForm extends Component {
               onFocus: this.handleInputFocus,
             }}
             isLoadingGoogle={isLoadingGoogle}
-            onChangeAddress={onChangeAddress}
+            onChangeAddress={this.handleAddressChange}
             placeholder={placeholder}
             rules={rules}
             useSearchBox
@@ -106,7 +120,7 @@ class SearchForm extends Component {
               <CountrySelector
                 address={address}
                 Input={DefaultInput}
-                onChangeAddress={onChangeAddress}
+                onChangeAddress={this.handleAddressChange}
                 shipsTo={shipsTo}
               />
             )}
@@ -115,7 +129,7 @@ class SearchForm extends Component {
               autoFocus
               address={address}
               Input={DefaultInput}
-              onChangeAddress={onChangeAddress}
+              onChangeAddress={this.handleAddressChange}
               rules={rules}
               inputProps={{
                 onBlur: this.handleInputBlur,

--- a/react/components/SearchForm.js
+++ b/react/components/SearchForm.js
@@ -57,7 +57,10 @@ class SearchForm extends Component {
       },
     }))
 
-    if (address.postalCode?.value) {
+    if (
+      address.postalCode?.value ||
+      address.geoCoordinates?.value?.length > 0
+    ) {
       this.props.onChangeAddress({ ...this.state.address, ...address })
     }
   }

--- a/react/components/SearchForm.js
+++ b/react/components/SearchForm.js
@@ -17,21 +17,6 @@ const { PostalCodeGetter, CountrySelector } = components
 const { GeolocationInput, DefaultInput } = inputs
 const { AddressShapeWithValidation } = shapes
 
-function compareGeoCoordinates(currentCoordinates, prevCoordinates) {
-  if (!currentCoordinates || currentCoordinates.length === 0) {
-    return false
-  }
-
-  if (!prevCoordinates || prevCoordinates.length === 0) {
-    return true
-  }
-
-  const [currentLat, currentLng] = currentCoordinates
-  const [prevLat, prevLng] = prevCoordinates
-
-  return currentLat !== prevLat || currentLng !== prevLng
-}
-
 class SearchForm extends Component {
   constructor(props) {
     super(props)
@@ -64,20 +49,6 @@ class SearchForm extends Component {
     this.props.getCurrentPosition()
   }
 
-  componentDidUpdate(_, prevState) {
-    if (
-      (this.state.address.postalCode?.value &&
-        this.state.address.postalCode.value !==
-          prevState.address.postalCode?.value) ||
-      compareGeoCoordinates(
-        this.state.address.geoCoordinates?.value,
-        prevState.address.geoCoordinates?.value
-      )
-    ) {
-      this.props.onChangeAddress(this.state.address)
-    }
-  }
-
   handleAddressChange = (address) => {
     this.setState((prevState) => ({
       address: {
@@ -85,6 +56,10 @@ class SearchForm extends Component {
         ...address,
       },
     }))
+
+    if (address.postalCode?.value) {
+      this.props.onChangeAddress({ ...this.state.address, ...address })
+    }
   }
 
   render() {


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR updates the address in the `SearchForm` component to be a state, and to 
only update the address in state on the callbacks of `PostalCodeGetter`. This 
component now will only call the prop `onChangeAddress` if the address in state 
have a postal code.

#### What problem is this solving?

This fixes an issue where if the store is from a country that uses the "levels" 
configuration, meaning that the user won't input a postal code but instead will 
select their state/city/neighborhood (depending on the country rules).

The issue is that after each selection, the `onChangeAddress` callback will be 
called with only that field filled.

For example, consider Peru's rules where it has 3 levels for state, city and 
neighborhood. After you select your state, in the example it will be Lima, the 
onChangeAddress callback would be called with the following object:

```js
{
  state: {
    value: 'Lima',
  }
}
```

Now that you have selected the state, you can select the city (which will also 
be Lima in our example), but after doing so the callback will be called with 
the following object:

```js
{
  city: {
    value: 'Lima'
  }
}
```

This would make the address-form reducer only use this value for the address, 
clearing the state value. And with this you wouldn't be able to select the last 
field (neighborhood) and proceed to choose a pickup point.

The fix was to keep this address in state, and always merge the existing object 
with the partial address that is received on the callback, and only to call the 
callback in the props when the address has the postal code field.

#### How should this be manually tested?

You can use [this workspace]. ~I still haven't been able to make the pickup 
point appear after selecting the address, but you can see that the bug has been 
fixed.~

I fixed the pickup point (was an issue with the logistics spreadsheet I uploaded to create this pickup point), so now you should be able to select it after entering an address such as Lima/Lima/Lima. You should be able to proceed to the payment step and finish the purchase. I also created an E2E test here vtex/checkout-ui-tests#144

[this workspace]: https://lucas--vtexgame1nogeo.myvtex.com/checkout/cart/add/?sku=296&qty=1&seller=1&sc=3

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
