### PR TITLE
Reset address on new search to avoid leaking geoCoordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Reset address on change to avoid using previous address geo coordinates.
 
-## [3.7.3] - 2022-08-18
+## [3.7.3] - 2022-08-18 [YANKED]
 ### Fixed
 - Address reset when inserted using levels configuration.
 

--- a/react/components/EmptySearch.js
+++ b/react/components/EmptySearch.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
+import { helpers } from 'vtex.address-form'
 
 import { translate } from '../utils/i18nUtils'
 import Input from './Input'
@@ -16,6 +17,9 @@ import {
   ERROR_NOT_FOUND,
 } from '../constants'
 import { injectState } from '../modalStateContext'
+import { newAddress } from '../utils/newAddress'
+
+const { addValidation } = helpers
 
 const getGeolocationErrorMessage = (status) => {
   switch (status) {
@@ -34,6 +38,18 @@ const getGeolocationErrorMessage = (status) => {
 }
 
 class EmptySearch extends PureComponent {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      address: addValidation(
+        newAddress({
+          country: props.searchAddress.country.value,
+        })
+      ),
+    }
+  }
+
   render() {
     const {
       askForGeolocation,
@@ -45,7 +61,6 @@ class EmptySearch extends PureComponent {
       loading,
       logisticsInfo,
       rules,
-      searchAddress,
       setGeolocationStatus,
       setActiveState,
       shouldUseMaps,
@@ -74,7 +89,7 @@ class EmptySearch extends PureComponent {
             )}
           </h3>
           <SearchForm
-            address={searchAddress}
+            address={this.state.address}
             // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
             askForGeolocation={askForGeolocation}

--- a/react/components/PickupPointInfo.js
+++ b/react/components/PickupPointInfo.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import TranslateEstimate from 'vtex.shipping-estimate-translator/TranslateEstimate'
-import { AddressSummary } from '@vtex/address-form'
+import { AddressSummary } from 'vtex.address-form'
 
 import { formatCurrency, formatNumber } from '../utils/Currency'
 import { formatDistance } from '../utils/Distance'

--- a/react/components/PickupPointInfo.js
+++ b/react/components/PickupPointInfo.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import TranslateEstimate from 'vtex.shipping-estimate-translator/TranslateEstimate'
-import { AddressSummary } from 'vtex.address-form'
+import { components } from 'vtex.address-form'
 
 import { formatCurrency, formatNumber } from '../utils/Currency'
 import { formatDistance } from '../utils/Distance'
@@ -15,6 +15,8 @@ import UnavailableMarker from '../assets/components/UnavailableMarker'
 import SearchMarkerIcon from '../assets/components/SearchMarkerIcon'
 import BestMarkerIcon from '../assets/components/BestMarkerIcon'
 import { getCleanId } from '../utils/StateUtils'
+
+const { AddressSummary } = components
 
 const MAX_KILOMETERS = 1000
 

--- a/react/package.json
+++ b/react/package.json
@@ -71,8 +71,10 @@
     "react-redux": "^5.0.7",
     "react-test-renderer": "^16.12.0",
     "redux": "^4.0.0",
-    "vtex.country-codes": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.country-codes@1.1.2/public/_types/react",
-    "vtex.render-runtime": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@7.39.1/public/_types/react",
-    "vtex.shipping-estimate-translator": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.shipping-estimate-translator@1.0.4/public/_types/react"
+    "vtex.address-form": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-form@3.27.1/public/@types/vtex.address-form",
+    "vtex.country-codes": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-codes@1.1.2/public/_types/react",
+    "vtex.pickup-points-modal": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pickup-points-modal@3.7.2/public/@types/vtex.pickup-points-modal",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@7.45.0/public/@types/vtex.render-runtime",
+    "vtex.shipping-estimate-translator": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@1.4.0/public/@types/vtex.shipping-estimate-translator"
   }
 }

--- a/react/utils/__tests__/newAddress.test.js
+++ b/react/utils/__tests__/newAddress.test.js
@@ -22,6 +22,7 @@ describe('newAddress', () => {
       state: null,
       street: null,
       addressQuery: '',
+      isDisposable: false,
     }
 
     const resultAddress = newAddress({

--- a/react/utils/newAddress.js
+++ b/react/utils/newAddress.js
@@ -1,6 +1,6 @@
 import getGGUID from './Gguid'
 
-export function newAddress(address) {
+export function newAddress(address = {}) {
   const {
     addressType,
     city,
@@ -16,6 +16,7 @@ export function newAddress(address) {
     street,
     addressQuery,
     addressId,
+    isDisposable,
   } = address
 
   return {
@@ -33,5 +34,6 @@ export function newAddress(address) {
     state: state || null,
     street: street || null,
     addressQuery: addressQuery || '',
+    isDisposable: isDisposable ?? false,
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6962,17 +6962,25 @@ vtex-tachyons@^3.2.0:
   resolved "https://registry.yarnpkg.com/vtex-tachyons/-/vtex-tachyons-3.2.2.tgz#e9e39d939778ef7d80a92c476cecf7417f79a6e8"
   integrity sha512-4M53uuvV+2XEjplVYiPgpBuaI5dtGksVgz/20NNjbZkXklJM7Lwgod/hOoh3PtIn36+95zZVVgXYfs3e6EU8YA==
 
-"vtex.country-codes@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.country-codes@1.1.2/public/_types/react":
-  version "0.0.0"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.country-codes@1.1.2/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+"vtex.address-form@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-form@3.27.1/public/@types/vtex.address-form":
+  version "3.27.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-form@3.27.1/public/@types/vtex.address-form#4b5702b3f7047090eb39a3dc909b404b4435b788"
 
-"vtex.render-runtime@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@7.39.1/public/_types/react":
-  version "7.39.1"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@7.39.1/public/_types/react#8c51998a3db63bb726dd4a61e4ad112c9db308a3"
-
-"vtex.shipping-estimate-translator@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.shipping-estimate-translator@1.0.4/public/_types/react":
+"vtex.country-codes@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-codes@1.1.2/public/_types/react":
   version "0.0.0"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.shipping-estimate-translator@1.0.4/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-codes@1.1.2/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+
+"vtex.pickup-points-modal@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pickup-points-modal@3.7.2/public/@types/vtex.pickup-points-modal":
+  version "3.7.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pickup-points-modal@3.7.2/public/@types/vtex.pickup-points-modal#2dcd183f44a3043b4164f685b0a951663e682e21"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@7.45.0/public/@types/vtex.render-runtime":
+  version "7.45.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@7.45.0/public/@types/vtex.render-runtime#d9c9c4bbe8efe698a6b6566cc22e9dd7687a2442"
+
+"vtex.shipping-estimate-translator@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@1.4.0/public/@types/vtex.shipping-estimate-translator":
+  version "1.4.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@1.4.0/public/@types/vtex.shipping-estimate-translator#428db63e7f358e8670ec82fc31a027c28bee5819"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updates the `EmptySearch` component to always pass an empty/new address to the search form.

This address will only reuse the country of the existing search address to avoid leaking undesirable fields to the new address (such as the geo coordinates).

#### What problem is this solving?

This fixes an issue with our latest deploy. It contained a bug where it would always reuse the geoCoordinates of the existing address in the orderForm.

This would make it impossible for the user to change their address (e.g. to search for pickups in a different location), because the API uses the geoCoordinates to search for pickups, not the zipcode.

#### How should this be manually tested?

I've added a regression test in vtex/checkout-ui-tests#146

#### Screenshots or example usage

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
