### PR TITLE
[CHK-3296]: Previne múltiplos Pickups Points para items de sellers whitelabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Fixed
 - Add rootPath to API requests.
+- Prevent multiple pickup point selection for items from white label sellers.
 
 ## [3.8.1] - 2023-09-11
 

--- a/react/fetchers/index.js
+++ b/react/fetchers/index.js
@@ -116,21 +116,22 @@ export function updateShippingData(
 
   const defaultDeliverySla = firstItemWithSelectedDelivery.selectedSla
 
-  const newLogisticsInfo = logisticsInfoWithPickupSelected.map((li) => {
-    const hasDefaultDeliverySla = li.slas.find(
-      (sla) => sla.id === defaultDeliverySla
-    )
+  const logisticsInfoWithDefaultDeliverySla =
+    logisticsInfoWithPickupSelected.map((li) => {
+      const hasDefaultDeliverySla = li.slas.find(
+        (sla) => sla.id === defaultDeliverySla
+      )
 
-    if (!li.selectedDeliveryChannel && hasDefaultDeliverySla) {
-      return {
-        ...li,
-        selectedSla: defaultDeliverySla,
-        selectedDeliveryChannel: DELIVERY,
+      if (!li.selectedDeliveryChannel && hasDefaultDeliverySla) {
+        return {
+          ...li,
+          selectedSla: defaultDeliverySla,
+          selectedDeliveryChannel: DELIVERY,
+        }
       }
-    }
 
-    return li
-  })
+      return li
+    })
 
   const shippingData = {
     ...(hasGeocoordinates ? { clearAddressIfPostalCodeNotFound: false } : {}),
@@ -138,7 +139,7 @@ export function updateShippingData(
       ...(residentialAddress ? [residentialAddress] : []),
       pickupAddressWithAddressId,
     ],
-    logisticsInfo: newLogisticsInfo,
+    logisticsInfo: logisticsInfoWithDefaultDeliverySla,
   }
 
   return (

--- a/react/fetchers/index.js
+++ b/react/fetchers/index.js
@@ -114,7 +114,8 @@ export function updateShippingData(
     logisticsInfoWithPickupSelected
   )
 
-  const defaultDeliverySla = firstItemWithSelectedDelivery.selectedSla
+  const defaultDeliverySla =
+    firstItemWithSelectedDelivery && firstItemWithSelectedDelivery.selectedSla
 
   const logisticsInfoWithDefaultDeliverySla =
     logisticsInfoWithPickupSelected.map((li) => {

--- a/react/fetchers/index.js
+++ b/react/fetchers/index.js
@@ -2,8 +2,11 @@ import axios from 'axios'
 import axiosRetry from 'axios-retry'
 
 import { newAddress } from '../utils/newAddress'
-import { PICKUP_IN_STORE, SEARCH } from '../constants'
-import { isDelivery } from '../utils/DeliveryChannelsUtils'
+import { DELIVERY, PICKUP_IN_STORE, SEARCH } from '../constants'
+import {
+  getFirstItemWithSelectedDelivery,
+  isPickup,
+} from '../utils/DeliveryChannelsUtils'
 
 axiosRetry(axios, { retries: 2 })
 
@@ -84,27 +87,58 @@ export function updateShippingData(
     addressType: SEARCH,
   })
 
+  const logisticsInfoWithPickupSelected = logisticsInfo.map((li) => {
+    const hasPickupSla = li.slas.some((sla) => sla.id === pickupPoint.id)
+    const shouldKeepSelectedSla = !isPickup(li)
+
+    return {
+      itemIndex: li.itemIndex,
+      slas: li.slas,
+      addressId: hasPickupSla
+        ? pickupAddressWithAddressId.addressId
+        : li.addressId,
+      selectedSla: hasPickupSla
+        ? pickupPoint.id
+        : shouldKeepSelectedSla
+        ? li.selectedSla
+        : null,
+      selectedDeliveryChannel: hasPickupSla
+        ? PICKUP_IN_STORE
+        : shouldKeepSelectedSla
+        ? li.selectedDeliveryChannel
+        : null,
+    }
+  })
+
+  const firstItemWithSelectedDelivery = getFirstItemWithSelectedDelivery(
+    logisticsInfoWithPickupSelected
+  )
+
+  const defaultDeliverySla = firstItemWithSelectedDelivery.selectedSla
+
+  const newLogisticsInfo = logisticsInfoWithPickupSelected.map((li) => {
+    const hasDefaultDeliverySla = li.slas.find(
+      (sla) => sla.id === defaultDeliverySla
+    )
+
+    if (!li.selectedDeliveryChannel && hasDefaultDeliverySla) {
+      return {
+        ...li,
+        selectedSla: defaultDeliverySla,
+        selectedDeliveryChannel: DELIVERY,
+      }
+    }
+
+    return li
+  })
+
   const shippingData = {
     ...(hasGeocoordinates ? { clearAddressIfPostalCodeNotFound: false } : {}),
     selectedAddresses: [
       ...(residentialAddress ? [residentialAddress] : []),
       pickupAddressWithAddressId,
     ],
-    logisticsInfo: logisticsInfo.map((li) => {
-      const hasSla = li.slas.some((sla) => sla.id === pickupPoint.id)
-      const hasDeliverySla = li.slas.some((sla) => isDelivery(sla))
-
-      return {
-        itemIndex: li.itemIndex,
-        addressId: hasSla ? pickupAddressWithAddressId.addressId : li.addressId,
-        selectedSla: hasSla ? pickupPoint.id : li.selectedSla,
-        selectedDeliveryChannel: hasSla
-          ? PICKUP_IN_STORE
-          : hasDeliverySla
-          ? li.selectedDeliveryChannel
-          : null,
-      }
-    }),
+    logisticsInfo: newLogisticsInfo,
   }
 
   return (

--- a/react/utils/DeliveryChannelsUtils.js
+++ b/react/utils/DeliveryChannelsUtils.js
@@ -32,3 +32,7 @@ export function isDelivery(deliveryChannelSource) {
 
   return deliveryChannel === DELIVERY
 }
+
+export function getFirstItemWithSelectedDelivery(logisticsInfo) {
+  return logisticsInfo.find((li) => isDelivery(li))
+}


### PR DESCRIPTION
### What is the purpose of this pull request?

O objetivo principal desse PR é prevenir a seleção acidental de múltiplos pickup points em um carrinho com itens de sellers whitelabel.

Agora, toda vez que um novo pickup point é escolhido, ele vai substituir qualquer outro previamente selecionado. Essa mudança procura evitar que tenhamos um cenário como da imagem abaixo. 

![image](https://github.com/vtex/pickup-points-modal/assets/12574426/c2df66e4-ef1b-40b5-8ec5-25f9d9840672)

No mais, agora usamos uma sla de `delivery`, em uso por outros itens do carrinho, como fallback para os casos em que um item vai estar indisponível para retirada no novo pickup point.

<!--- Describe your changes in detail. -->

### What problem is this solving?

Além do objetivo principal, esse PR também resolve alguns outros problemas. Dependendo da combinação de itens, o usuário não consegue selecionar um pickup point, por exemplo. Você pode notar isso seguindo os seguintes passos:

- Acessar [esse cartlink](https://magicfeet.myvtex.com/checkout/cart/add/?sku=2095673&qty=1&seller=1&sc=1&sku=2001831&qty=1&seller=1&sc=1&sku=2097612&qty=1&seller=1&sc=1&sku=2094839&qty=1&seller=1&sc=1&sku=2095672&qty=1&seller=1&sc=1&sku=2103307&qty=1&seller=1&sc=1&sku=2097636&qty=1&seller=1&sc=1)
- No carrinho, abrir o shipping preview e seguir para Pickup
- Busque por pickup points usando o cep `01310930`
- Escolha "Retirada em Shopping Analia Franco"
- O componente de shipping vai ignorar completamente a escolha.


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- [Add itens no carrinho](https://jeff--magicfeet.myvtex.com/checkout/cart/add/?sku=2095673&qty=1&seller=1&sc=1&sku=2001831&qty=1&seller=1&sc=1&sku=2097612&qty=1&seller=1&sc=1&sku=2094839&qty=1&seller=1&sc=1&sku=2095672&qty=1&seller=1&sc=1&sku=2103307&qty=1&seller=1&sc=1&sku=2097636&qty=1&seller=1&sc=1)
- No carrinho, abrir o shipping preview e seguir para Pickup
- Busque por pickup points usando o cep `01310930`
- Escolha "Retirada em Shopping Analia Franco"
- Verifique o `network` do seu navegador e procure pelo request de `shippingData`
- Apenas o ponto de retirada escolhido vai ser enviado para API
- Além disso, o componente de shipping deve refletir a escolha certa do pickup point

#### Screenshots or example usage

![image](https://github.com/vtex/pickup-points-modal/assets/12574426/81402607-344d-444a-a2c2-a67401ea2bd9)


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
