### PR TITLE
chore: add test execution to CI pipeline

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -6,6 +6,9 @@
     pipelines:
       - name: node-ci-v2
         parameters:
+          nodeCommands:
+            - install
+            - test:coverage
           sonarProjectName: pickup-points-modal
           nodeVersion: 20-bookworm
         runtime:

--- a/react/package.json
+++ b/react/package.json
@@ -11,7 +11,8 @@
     "removeMocks": "rm -rf lib/**/__mocks__ && rm -rf lib/__mocks__ && rm -rf dist",
     "addLocales": "cp -R -f react/locales/ lib/locales/",
     "postreleasy": "npm publish --access public",
-    "test": "vtex-test-tools test"
+    "test": "vtex-test-tools test",
+    "test:coverage": "vtex-test-tools test --coverage"
   },
   "keywords": [
     "react-component",


### PR DESCRIPTION
## Summary
- Add `test:coverage` script to package.json
- Add `nodeCommands` with test step to `.vtex/deployment.yaml` so CI runs tests on PRs

## Context
Part of test-execution rollout for Checkout Experience repos. Goal: every repo runs its test suite on every PR via DK CI.

## Test plan
- [ ] Verify pipeline runs on this PR at http://dkcicd.vtex.systems/
- [ ] Verify test step executes (or stub passes if no tests)
- [ ] Confirm no regressions in existing pipeline steps

> **Note:** Any pre-existing CI failures on this repo are unrelated to this change.

> **Notes for maintainer:** MISSING referenceId - maintainer must add before merge; 
