### PR TITLE
ci: bump actions/cache v2 → v4 to unblock CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - run: |
           yarn install --frozen-lockfile --check-files
           yarn --cwd react install --frozen-lockfile --check-files
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache-build
         with:
           path: ./*
@@ -30,7 +30,7 @@ jobs:
     needs: install
     steps:
     - name: Restore cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: restore-build
       with:
         path: ./*
@@ -42,7 +42,7 @@ jobs:
     needs: install
     steps:
     - name: Restore cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: restore-build
       with:
         path: ./*


### PR DESCRIPTION
## Problem
GitHub now **automatically hard-fails** any workflow that uses the deprecated `actions/cache@v2`. In `.github/workflows/ci.yml` this breaks the `install` job at the "Getting action download info" step, which cascades to `test`, `lint`, and all Cypress `link-app` / `delete-workspace` jobs.

Reference: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

## Fix
Bump the three `actions/cache@v2` usages to `@v4`. This unblocks CI for all open PRs in the repo.

## Note
The workflow also uses other very old actions (`actions/checkout@v1`, `actions/setup-node@v1`). Those aren't hard-failed yet, so they're left out of this focused fix — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)